### PR TITLE
feat: update API URLs to use /v1 versioned endpoints

### DIFF
--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: false,
   showGithubActivity: false,
+  screenshotMode: false,
   apiUrl: 'https://your-api-url.example.com/v1',
 };

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   showGithubActivity: false,
-  apiUrl: 'https://your-api-url.example.com',
+  apiUrl: 'https://your-api-url.example.com/v1',
 };

--- a/src/environments/environment.prod.example.ts
+++ b/src/environments/environment.prod.example.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   showGithubActivity: false,
-  apiUrl: 'https://your-api-url.example.com',
+  apiUrl: 'https://your-api-url.example.com/v1',
 };

--- a/src/environments/environment.prod.example.ts
+++ b/src/environments/environment.prod.example.ts
@@ -2,4 +2,5 @@ export const environment = {
   production: true,
   showGithubActivity: false,
   apiUrl: 'https://your-api-url.example.com/v1',
+  screenshotMode: false,
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -3,6 +3,6 @@ import { Environment } from './environment.interface';
 export const environment: Environment = {
   production: true,
   showGithubActivity: false,
-  apiUrl: 'https://api.3dime.com',
+  apiUrl: 'https://api.3dime.com/v1',
   screenshotMode: false,
 };

--- a/src/environments/environment.screenshot.ts
+++ b/src/environments/environment.screenshot.ts
@@ -9,5 +9,5 @@ export const environment: Environment = {
   production: true,
   screenshotMode: true,
   showGithubActivity: true,
-  apiUrl: 'https://api.3dime.com',
+  apiUrl: 'https://api.3dime.com/v1',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,5 +3,5 @@ import { Environment } from './environment.interface';
 export const environment: Environment = {
   production: false,
   screenshotMode: false,
-  apiUrl: 'http://localhost:8080',
+  apiUrl: 'http://localhost:8080/v1',
 };


### PR DESCRIPTION
## Summary
- Append `/v1` to `apiUrl` in all environment files to match the new versioned API endpoints in 3dime-api
- Affects: `environment.ts`, `environment.prod.ts`, `environment.screenshot.ts`, `environment.example.ts`, `environment.prod.example.ts`

## Test plan
- [ ] Verify API calls go to `/v1/github/user`, `/v1/notion/cms`, etc.
- [ ] Deploy simultaneously with m-idriss/3dime-api PR (breaking change coordination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)