### PR TITLE
[codex] Improve cached data loading

### DIFF
--- a/src/app/services/github.service.ts
+++ b/src/app/services/github.service.ts
@@ -52,6 +52,11 @@ export interface GithubRelease {
   published_at?: string;
 }
 
+interface CachedData<T> {
+  data: T;
+  isFresh: boolean;
+}
+
 /**
  * Service for fetching GitHub profile data and commit activity.
  * Uses caching with shareReplay to prevent duplicate API calls.
@@ -82,18 +87,20 @@ export class GithubService {
 
   private profile$?: Observable<GithubUser>;
   private socialLinks$?: Observable<SocialLink[]>;
-  private commits$?: Observable<CommitData[]>;
+  private readonly commitsByMonths = new Map<number, Observable<CommitData[]>>();
   private release$?: Observable<GithubRelease>;
 
   private readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-  private getCached<T>(key: string): T | null {
+  private getCached<T>(key: string): CachedData<T> | null {
     try {
       const raw = localStorage.getItem(key);
       if (!raw) return null;
       const { data, timestamp } = JSON.parse(raw) as { data: T; timestamp: number };
-      if (Date.now() - timestamp > this.CACHE_TTL_MS) return null;
-      return data;
+      return {
+        data,
+        isFresh: Date.now() - timestamp <= this.CACHE_TTL_MS,
+      };
     } catch {
       return null;
     }
@@ -130,9 +137,13 @@ export class GithubService {
         }),
         shareReplay(1),
       );
-      if (cached) {
-        this.profile$ = of(cached).pipe(shareReplay(1));
-        fresh$.subscribe({ error: (err) => console.warn('Background profile refresh failed:', err.message || err) });
+      if (cached?.data) {
+        this.profile$ = of(cached.data).pipe(shareReplay(1));
+        if (!cached.isFresh) {
+          fresh$.subscribe({
+            error: (err) => console.warn('Background profile refresh failed:', err.message || err),
+          });
+        }
       } else {
         this.profile$ = fresh$;
       }
@@ -163,9 +174,13 @@ export class GithubService {
         }),
         shareReplay(1),
       );
-      if (cached) {
-        this.socialLinks$ = of(cached).pipe(shareReplay(1));
-        fresh$.subscribe({ error: (err) => console.warn('Background social refresh failed:', err.message || err) });
+      if (cached?.data) {
+        this.socialLinks$ = of(cached.data).pipe(shareReplay(1));
+        if (!cached.isFresh) {
+          fresh$.subscribe({
+            error: (err) => console.warn('Background social refresh failed:', err.message || err),
+          });
+        }
       } else {
         this.socialLinks$ = fresh$;
       }
@@ -185,22 +200,44 @@ export class GithubService {
     if (env.screenshotMode) {
       return of(MOCK_COMMIT_DATA).pipe(shareReplay(1));
     }
+    const cachedCommits$ = this.commitsByMonths.get(months);
+    if (cachedCommits$) {
+      return cachedCommits$;
+    }
+
     const url = `${this.endpoints.commits}?months=${months}`;
-    return this.http.get<CommitData[]>(url).pipe(
+    const cacheKey = `github_commits_${months}`;
+    const cached = this.getCached<CommitData[]>(cacheKey);
+    const fresh$ = this.http.get<CommitData[]>(url).pipe(
       timeout(API_CONFIG.TIMEOUT_MS),
+      tap((data) => this.setCache(cacheKey, data)),
       catchError((err) => {
         console.warn('Commits API call failed or timed out:', err.message || err);
         return of([]);
       }),
       shareReplay(1),
     );
+
+    if (cached?.data) {
+      const cached$ = of(cached.data).pipe(shareReplay(1));
+      this.commitsByMonths.set(months, cached$);
+      if (!cached.isFresh) {
+        fresh$.subscribe({
+          error: (err) => console.warn('Background commits refresh failed:', err.message || err),
+        });
+      }
+    } else {
+      this.commitsByMonths.set(months, fresh$);
+    }
+
+    return this.commitsByMonths.get(months)!;
   }
 
   /**
    * Clear cached commit data to force a refresh on next request.
    */
   refreshCommits(): void {
-    this.commits$ = undefined;
+    this.commitsByMonths.clear();
   }
 
   /**
@@ -227,9 +264,13 @@ export class GithubService {
         }),
         shareReplay(1),
       );
-      if (cached) {
-        this.release$ = of(cached).pipe(shareReplay(1));
-        fresh$.subscribe({ error: (err) => console.warn('Background release refresh failed:', err.message || err) });
+      if (cached?.data) {
+        this.release$ = of(cached.data).pipe(shareReplay(1));
+        if (!cached.isFresh) {
+          fresh$.subscribe({
+            error: (err) => console.warn('Background release refresh failed:', err.message || err),
+          });
+        }
       } else {
         this.release$ = fresh$;
       }

--- a/src/app/services/github.service.ts
+++ b/src/app/services/github.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { EMPTY, Observable, of } from 'rxjs';
 import { shareReplay, catchError, timeout, tap } from 'rxjs/operators';
 
 import { environment } from '../../environments/environment';
@@ -114,6 +114,25 @@ export class GithubService {
     }
   }
 
+  private sharedValue<T>(data: T): Observable<T> {
+    return of(data).pipe(shareReplay(1));
+  }
+
+  private refreshInBackground<T>(
+    fresh$: Observable<T>,
+    cacheObservable: (value$: Observable<T>) => void,
+    label: string,
+  ): void {
+    fresh$
+      .pipe(
+        catchError((err) => {
+          console.warn(`Background ${label} refresh failed:`, err.message || err);
+          return EMPTY;
+        }),
+      )
+      .subscribe((data) => cacheObservable(this.sharedValue(data)));
+  }
+
   /**
    * Get GitHub user profile.
    * Caches the result to prevent duplicate API calls.
@@ -131,21 +150,21 @@ export class GithubService {
       const fresh$ = this.http.get<GithubUser>(this.endpoints.profile).pipe(
         timeout(API_CONFIG.TIMEOUT_MS),
         tap((data) => this.setCache('github_profile', data)),
-        catchError((err) => {
-          console.warn('Profile API call failed or timed out:', err.message || err);
-          return of({} as GithubUser);
-        }),
         shareReplay(1),
       );
       if (cached?.data) {
-        this.profile$ = of(cached.data).pipe(shareReplay(1));
+        this.profile$ = this.sharedValue(cached.data);
         if (!cached.isFresh) {
-          fresh$.subscribe({
-            error: (err) => console.warn('Background profile refresh failed:', err.message || err),
-          });
+          this.refreshInBackground(fresh$, (value$) => (this.profile$ = value$), 'profile');
         }
       } else {
-        this.profile$ = fresh$;
+        this.profile$ = fresh$.pipe(
+          catchError((err) => {
+            console.warn('Profile API call failed or timed out:', err.message || err);
+            return of({} as GithubUser);
+          }),
+          shareReplay(1),
+        );
       }
     }
     return this.profile$;
@@ -168,21 +187,21 @@ export class GithubService {
       const fresh$ = this.http.get<SocialLink[]>(this.endpoints.social).pipe(
         timeout(API_CONFIG.TIMEOUT_MS),
         tap((data) => this.setCache('github_social', data)),
-        catchError((err) => {
-          console.warn('Social links API call failed or timed out:', err.message || err);
-          return of([]);
-        }),
         shareReplay(1),
       );
       if (cached?.data) {
-        this.socialLinks$ = of(cached.data).pipe(shareReplay(1));
+        this.socialLinks$ = this.sharedValue(cached.data);
         if (!cached.isFresh) {
-          fresh$.subscribe({
-            error: (err) => console.warn('Background social refresh failed:', err.message || err),
-          });
+          this.refreshInBackground(fresh$, (value$) => (this.socialLinks$ = value$), 'social');
         }
       } else {
-        this.socialLinks$ = fresh$;
+        this.socialLinks$ = fresh$.pipe(
+          catchError((err) => {
+            console.warn('Social links API call failed or timed out:', err.message || err);
+            return of([]);
+          }),
+          shareReplay(1),
+        );
       }
     }
     return this.socialLinks$;
@@ -211,23 +230,26 @@ export class GithubService {
     const fresh$ = this.http.get<CommitData[]>(url).pipe(
       timeout(API_CONFIG.TIMEOUT_MS),
       tap((data) => this.setCache(cacheKey, data)),
-      catchError((err) => {
-        console.warn('Commits API call failed or timed out:', err.message || err);
-        return of([]);
-      }),
       shareReplay(1),
     );
 
     if (cached?.data) {
-      const cached$ = of(cached.data).pipe(shareReplay(1));
+      const cached$ = this.sharedValue(cached.data);
       this.commitsByMonths.set(months, cached$);
       if (!cached.isFresh) {
-        fresh$.subscribe({
-          error: (err) => console.warn('Background commits refresh failed:', err.message || err),
-        });
+        this.refreshInBackground(fresh$, (value$) => this.commitsByMonths.set(months, value$), 'commits');
       }
     } else {
-      this.commitsByMonths.set(months, fresh$);
+      this.commitsByMonths.set(
+        months,
+        fresh$.pipe(
+          catchError((err) => {
+            console.warn('Commits API call failed or timed out:', err.message || err);
+            return of([]);
+          }),
+          shareReplay(1),
+        ),
+      );
     }
 
     return this.commitsByMonths.get(months)!;
@@ -258,21 +280,21 @@ export class GithubService {
       const fresh$ = this.http.get<GithubRelease>(url).pipe(
         timeout(API_CONFIG.TIMEOUT_MS),
         tap((data) => this.setCache('github_release', data)),
-        catchError((err) => {
-          console.warn('Release API call failed or timed out:', err.message || err);
-          return of({} as GithubRelease);
-        }),
         shareReplay(1),
       );
       if (cached?.data) {
-        this.release$ = of(cached.data).pipe(shareReplay(1));
+        this.release$ = this.sharedValue(cached.data);
         if (!cached.isFresh) {
-          fresh$.subscribe({
-            error: (err) => console.warn('Background release refresh failed:', err.message || err),
-          });
+          this.refreshInBackground(fresh$, (value$) => (this.release$ = value$), 'release');
         }
       } else {
-        this.release$ = fresh$;
+        this.release$ = fresh$.pipe(
+          catchError((err) => {
+            console.warn('Release API call failed or timed out:', err.message || err);
+            return of({} as GithubRelease);
+          }),
+          shareReplay(1),
+        );
       }
     }
     return this.release$;

--- a/src/app/services/notion.service.ts
+++ b/src/app/services/notion.service.ts
@@ -18,6 +18,11 @@ interface NotionApiResponse {
   tech_stack?: LinkItem[];
 }
 
+interface CachedNotion {
+  data: NotionApiResponse;
+  isFresh: boolean;
+}
+
 /**
  * Delay between progressive item emissions in milliseconds.
  * This creates a staggered effect where items appear one by one.
@@ -53,13 +58,15 @@ export class NotionService {
   private readonly NOTION_CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
   private readonly NOTION_CACHE_KEY = 'notion_cms';
 
-  private getCachedNotion(): NotionApiResponse | null {
+  private getCachedNotion(): CachedNotion | null {
     try {
       const raw = localStorage.getItem(this.NOTION_CACHE_KEY);
       if (!raw) return null;
       const { data, timestamp } = JSON.parse(raw) as { data: NotionApiResponse; timestamp: number };
-      if (Date.now() - timestamp > this.NOTION_CACHE_TTL_MS) return null;
-      return data;
+      return {
+        data,
+        isFresh: Date.now() - timestamp <= this.NOTION_CACHE_TTL_MS,
+      };
     } catch {
       return null;
     }
@@ -113,18 +120,20 @@ export class NotionService {
         shareReplay(1),
       );
 
-      if (cached) {
-        // Pre-populate arrays immediately from cache so progressive loading starts at once
-        this.stuffs = cached.stuff ?? [];
-        this.experiences = cached.experience ?? [];
-        this.educations = cached.education ?? [];
-        this.hobbies = cached.hobbies ?? [];
-        this.techStacks = cached.tech_stack ?? [];
+      if (cached?.data) {
+        // Pre-populate arrays immediately from cache so content renders without waiting on the API.
+        this.stuffs = cached.data.stuff ?? [];
+        this.experiences = cached.data.experience ?? [];
+        this.educations = cached.data.education ?? [];
+        this.hobbies = cached.data.hobbies ?? [];
+        this.techStacks = cached.data.tech_stack ?? [];
         // Emit immediately so components can render; refresh cache silently in background
         this.fetchAll$ = of<void>(undefined).pipe(shareReplay(1));
-        fresh$.subscribe({
-          error: (err) => console.warn('Background Notion refresh failed:', err.message || err),
-        });
+        if (!cached.isFresh) {
+          fresh$.subscribe({
+            error: (err) => console.warn('Background Notion refresh failed:', err.message || err),
+          });
+        }
       } else {
         this.fetchAll$ = fresh$;
       }

--- a/src/app/services/notion.service.ts
+++ b/src/app/services/notion.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of, from, concat } from 'rxjs';
+import { EMPTY, Observable, of, from, concat } from 'rxjs';
 import { map, catchError, shareReplay, timeout, concatMap, delay } from 'rxjs/operators';
 
 import { LinkItem } from '../models';
@@ -80,6 +80,22 @@ export class NotionService {
     }
   }
 
+  private applyNotionContent(res: NotionApiResponse): void {
+    this.stuffs = res.stuff ?? [];
+    this.experiences = res.experience ?? [];
+    this.educations = res.education ?? [];
+    this.hobbies = res.hobbies ?? [];
+    this.techStacks = res.tech_stack ?? [];
+  }
+
+  private applyEmptyContent(): void {
+    this.stuffs = [];
+    this.experiences = [];
+    this.educations = [];
+    this.hobbies = [];
+    this.techStacks = [];
+  }
+
   stuffs: LinkItem[] = [];
   experiences: LinkItem[] = [];
   educations: LinkItem[] = [];
@@ -101,41 +117,36 @@ export class NotionService {
       const fresh$ = this.http.get<NotionApiResponse>(`${this.baseUrl}/notion/cms`).pipe(
         timeout(API_CONFIG.TIMEOUT_MS),
         map((res) => {
-          this.stuffs = res.stuff ?? [];
-          this.experiences = res.experience ?? [];
-          this.educations = res.education ?? [];
-          this.hobbies = res.hobbies ?? [];
-          this.techStacks = res.tech_stack ?? [];
+          this.applyNotionContent(res);
           this.setCacheNotion(res);
-        }),
-        catchError((err) => {
-          console.warn('Notion API call failed or timed out:', err.message || err);
-          this.stuffs = [];
-          this.experiences = [];
-          this.educations = [];
-          this.hobbies = [];
-          this.techStacks = [];
-          return of();
         }),
         shareReplay(1),
       );
 
       if (cached?.data) {
         // Pre-populate arrays immediately from cache so content renders without waiting on the API.
-        this.stuffs = cached.data.stuff ?? [];
-        this.experiences = cached.data.experience ?? [];
-        this.educations = cached.data.education ?? [];
-        this.hobbies = cached.data.hobbies ?? [];
-        this.techStacks = cached.data.tech_stack ?? [];
-        // Emit immediately so components can render; refresh cache silently in background
+        this.applyNotionContent(cached.data);
+        // Emit immediately so components can render; refresh memory and localStorage silently.
         this.fetchAll$ = of<void>(undefined).pipe(shareReplay(1));
         if (!cached.isFresh) {
-          fresh$.subscribe({
-            error: (err) => console.warn('Background Notion refresh failed:', err.message || err),
-          });
+          fresh$
+            .pipe(
+              catchError((err) => {
+                console.warn('Background Notion refresh failed:', err.message || err);
+                return EMPTY;
+              }),
+            )
+            .subscribe();
         }
       } else {
-        this.fetchAll$ = fresh$;
+        this.fetchAll$ = fresh$.pipe(
+          catchError((err) => {
+            console.warn('Notion API call failed or timed out:', err.message || err);
+            this.applyEmptyContent();
+            return of();
+          }),
+          shareReplay(1),
+        );
       }
     }
     return this.fetchAll$;


### PR DESCRIPTION
## Summary

- Render cached Notion content immediately, even when the local cache is stale, then refresh it in the background.
- Apply the same stale-while-revalidate behavior to GitHub profile, social links, releases, and commit activity.
- Cache GitHub commits by requested month window to avoid duplicate activity requests without mixing different ranges.

## Why

The portfolio could show loading skeletons while waiting for API responses, especially when backend cold starts or network latency delayed Notion/GitHub endpoints. Existing cache entries were ignored once they exceeded their TTL, so returning visitors could still experience a slow data render.

## Impact

Returning visitors should see portfolio data almost instantly from local cache while the app refreshes stale data silently in the background. Fresh visits still use the API path as before.

## Validation

- /Users/idriss/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node ./node_modules/typescript/bin/tsc -p config/tsconfig.app.json --noEmit